### PR TITLE
fix regexp for wan_interface

### DIFF
--- a/omnia-led-colors
+++ b/omnia-led-colors
@@ -33,7 +33,7 @@ function wan_led()
 
   for line in devfd:lines() do
     local bytes_in, pkt_in, bytes_out, pkt_out
-    local pat = wan_interface..":%s*(%d+)%s+(%d+)%s+%d+%s+%d+%s+%d+%s+%d+%s+%d+%s+%d+%s+(%d+)%s+(%d+)%s+"
+    local pat = "^%s+"..wan_interface..":%s*(%d+)%s+(%d+)%s+%d+%s+%d+%s+%d+%s+%d+%s+%d+%s+%d+%s+(%d+)%s+(%d+)%s+"
     _, _, bytes_in, pkt_in, bytes_out, pkt_out = string.find(line, pat)
 
     if bytes_in ~= nil then


### PR DESCRIPTION
otherwise also interfaces with names ending in e.g. eth1 (e.g. ifb4eth1 on my turris) are matched. the change ensures that only the exact name given is matched.